### PR TITLE
Fix bower command in ansible

### DIFF
--- a/deploy/setup_server.yml
+++ b/deploy/setup_server.yml
@@ -50,6 +50,7 @@
 
     - name: install clientside dependencies with bower
       bower: path={{srv_dir}}/{{app_name}}/src
+      sudo: no
 
     - name: install backend dependencies with pip
       pip: requirements={{srv_dir}}/{{app_name}}/src/requirements.txt virtualenv={{srv_dir}}/{{app_name}}/env state=present virtualenv_command=pyvenv


### PR DESCRIPTION
IFS-35. bower can be run without root permissions


This will fix an bower error. But for some reason, out client side build is broken again. I can't see anything on our page.
Everybody should support our development environment, I can't fix it after each commit.