### PR TITLE
IFS-48: Back end for 'get comments' API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -148,6 +148,10 @@ Content:
                 "description": "A comment",
                 "type": "object",
                 "properties": {
+                    "id": {
+                        "description": "ID of comment",
+                        "type": "integer"
+                    },
                     "content": {
                         "description": "Text content of comment",
                         "type": "string"

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,6 +163,28 @@ Content:
 }
 ```
 
+#### Error Responses
+
+##### Lecture Not Found
+
+The `lecture-id` parameter provided was not found.
+
+Code: 404
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "message": {
+            "description": "Error message",
+            "type": "string"
+        }
+    }
+}
+```
+
+
 ### <a name="example"></a>Example API (not implemented)
 Retrieve a sum of money.
 

--- a/manage.py
+++ b/manage.py
@@ -6,6 +6,8 @@ from flask.ext.script import Manager
 from server import app
 from server.models import db
 
+from server.models import Lecturer, Course, Lecture, Comment
+
 manager = Manager(app)
 
 
@@ -14,6 +16,28 @@ def init_db():
     """ Initialize database: drop and create all columns """
     db.drop_all()
     db.create_all()
+
+
+@manager.command
+def mock_db():
+    """ Insert mock data into database """
+    init_db()
+
+    simon = Lecturer('Simon', 'McCallum')
+    db.session.add(simon)
+
+    imt3601 = Course('IMT3601 - Game Programming', simon)
+    db.session.add(imt3601)
+
+    imt3601_l1 = Lecture('Lecture 1', imt3601)
+    db.session.add(imt3601_l1)
+
+    imt3601_l1_c1 = Comment('This is boring', imt3601_l1)
+    db.session.add(imt3601_l1_c1)
+    imt3601_l1_c2 = Comment('This is fun!', imt3601_l1)
+    db.session.add(imt3601_l1_c2)
+
+    db.session.commit()
 
 
 @manager.command

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.10.1
 Flask-SQLAlchemy==2.0
 Flask-Script==2.0.5
+Flask-RESTful==0.3.4
 Jinja2==2.8
 MarkupSafe==0.23
 SQLAlchemy==1.0.8

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -4,6 +4,7 @@ from flask import Flask
 
 from .models import db
 from .main.main import main
+from .resources import api
 
 app = Flask(__name__)
 
@@ -15,3 +16,5 @@ if not app.config.from_envvar('IFS_SETTINGS', silent=True):
 app.register_blueprint(main)
 
 db.init_app(app)
+
+api.init_app(app)

--- a/server/models.py
+++ b/server/models.py
@@ -43,6 +43,7 @@ class Lecture(db.Model):
     name = db.Column(db.String(), nullable=False)
     course_id = db.Column(db.Integer, db.ForeignKey('course.id'), nullable=False)
     quizzes = db.relationship('Quiz', backref='lecture')
+    lectures = db.relationship('Comment', backref='lecture')
 
     def __init__(self, name, course):
         self.name = name
@@ -65,3 +66,16 @@ class Quiz(db.Model):
 
     def __repr__(self):
         return "<Quiz {}>".format(self.id)
+
+
+class Comment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.String(), nullable=False)
+    lecture_id = db.Column(db.Integer, db.ForeignKey('lecture.id'), nullable=False)
+
+    def __init__(self, content, lecture):
+        self.content = content
+        self.lecture = lecture
+
+    def __repr__(self):
+        return "<Comment {}>".format(self.id)

--- a/server/resources.py
+++ b/server/resources.py
@@ -6,9 +6,9 @@ api = Api()
 
 class CommentListResource(Resource):
     def get(self, lecture_id):
-        db_lectures = Lecture.query.filter(Lecture.id == lecture_id).all()
+        db_lecture = Lecture.query.filter(Lecture.id == lecture_id).first()
 
-        if not db_lectures:
+        if not db_lecture:
             abort(404, message="Lecture {} does not exist".format(lecture_id))
 
         db_comments = Comment.query.filter(Comment.lecture_id == lecture_id)

--- a/server/resources.py
+++ b/server/resources.py
@@ -1,0 +1,25 @@
+from flask_restful import Resource, Api, abort
+from .models import Comment, Lecture
+
+api = Api()
+
+class CommentListResource(Resource):
+    def get(self, lecture_id):
+        db_lectures = Lecture.query.filter(Lecture.id == lecture_id).all()
+
+        if not db_lectures:
+            abort(404, message="Lecture {} does not exist".format(lecture_id))
+
+        db_comments = Comment.query.filter(Comment.lecture_id == lecture_id)
+
+        comments = [{
+            'id': c.id,
+            'content': c.content}
+            for c in db_comments]
+
+        return {
+            'comments': comments
+        }
+
+
+api.add_resource(CommentListResource, '/api/0/lectures/<lecture_id>/comments')

--- a/server/resources.py
+++ b/server/resources.py
@@ -3,6 +3,7 @@ from .models import Comment, Lecture
 
 api = Api()
 
+
 class CommentListResource(Resource):
     def get(self, lecture_id):
         db_lectures = Lecture.query.filter(Lecture.id == lecture_id).all()
@@ -12,10 +13,10 @@ class CommentListResource(Resource):
 
         db_comments = Comment.query.filter(Comment.lecture_id == lecture_id)
 
-        comments = [{
-            'id': c.id,
-            'content': c.content}
-            for c in db_comments]
+        comments = [
+            {'id': c.id, 'content': c.content}
+            for c in db_comments
+        ]
 
         return {
             'comments': comments

--- a/server/tests/base.py
+++ b/server/tests/base.py
@@ -9,8 +9,8 @@ class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
         self.db_fd, self.test_db_path = tempfile.mkstemp('.db')
-        test_db_uri = 'sqlite:///{}'.format(self.test_db_path)
-        app.config['SQLALCHEMY_DATABASE_URI'] = test_db_uri
+        # test_db_uri = 'sqlite:///{}'.format(self.test_db_path)
+        # app.config['SQLALCHEMY_DATABASE_URI'] = test_db_uri
         app.config['TESTING'] = True
         self.app = app.test_client()
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,0 +1,46 @@
+from server.tests.base import BaseTestCase
+from server.models import db, Lecturer, Course, Lecture, Comment
+import json
+
+class GetCommentsApiTest(BaseTestCase):
+    def setUp(self):
+        super(GetCommentsApiTest, self).setUp()
+
+        simon = Lecturer('Simon', 'McCallum')
+        db.session.add(simon)
+
+        imt3601 = Course('IMT3601 - Game Programming', simon)
+        db.session.add(imt3601)
+
+        imt3601_l1 = Lecture('Lecture 1', imt3601)
+        db.session.add(imt3601_l1)
+
+        imt3601_l1_c1 = Comment('This is boring', imt3601_l1)
+        imt3601_l1_c2 = Comment('This is fun!', imt3601_l1)
+        db.session.add(imt3601_l1_c1)
+        db.session.add(imt3601_l1_c2)
+
+        db.session.commit()
+
+    def test_success(self):
+        rv = self.app.get('/api/0/lectures/1/comments')
+        assert rv.status_code == 200
+
+    def test_lecture_not_found(self):
+        rv = self.app.get('/api/0/lectures/2/comments')
+        assert rv.status_code == 404
+
+    def test_list(self):
+        rv = self.app.get('/api/0/lectures/1/comments')
+        assert rv.headers['Content-Type'] == 'application/json'
+
+        response = json.loads(rv.data.decode('utf-8'))
+        assert len(response['comments']) == 2
+
+    def test_content(self):
+        rv = self.app.get('/api/0/lectures/1/comments')
+        assert rv.headers['Content-Type'] == 'application/json'
+
+        response = json.loads(rv.data.decode('utf-8'))
+
+        assert response['comments'][0]['content'] == 'This is boring'

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -22,22 +22,28 @@ class GetCommentsApiTest(BaseTestCase):
 
         db.session.commit()
 
-    def test_success(self):
+    def test_all(self):
+        self._test_success()
+        self._test_lecture_not_found()
+        self._test_list()
+        self._test_content()
+
+    def _test_success(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.status_code == 200
 
-    def test_lecture_not_found(self):
+    def _test_lecture_not_found(self):
         rv = self.app.get('/api/0/lectures/2/comments')
         assert rv.status_code == 404
 
-    def test_list(self):
+    def _test_list(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 
         response = json.loads(rv.data.decode('utf-8'))
         assert len(response['comments']) == 2
 
-    def test_content(self):
+    def _test_content(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -23,28 +23,22 @@ class GetCommentsApiTest(BaseTestCase):
 
         db.session.commit()
 
-    def test_all(self):
-        self._test_success()
-        self._test_lecture_not_found()
-        self._test_list()
-        self._test_content()
-
-    def _test_success(self):
+    def test_success(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.status_code == 200
 
-    def _test_lecture_not_found(self):
+    def test_lecture_not_found(self):
         rv = self.app.get('/api/0/lectures/2/comments')
         assert rv.status_code == 404
 
-    def _test_list(self):
+    def test_list(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 
         response = json.loads(rv.data.decode('utf-8'))
         assert len(response['comments']) == 2
 
-    def _test_content(self):
+    def test_content(self):
         rv = self.app.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,6 +1,7 @@
+import json
 from server.tests.base import BaseTestCase
 from server.models import db, Lecturer, Course, Lecture, Comment
-import json
+
 
 class GetCommentsApiTest(BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
As requested by @uvNikita , I added an 'id' field to each comment so that the client can know which ID a comment has. I also added an error specification for when the lecture could not be found.

I had to work around an issue in the python tests where more than one test will cause issues with the database access. @uvNikita  is looking into it.

To make this work with some actual comments, you can run 'manage mock_db' to initialize a database with some mock data (such as comments).

I'd like @uvNikita to approve this PR before merging it.