### PR TITLE
Fix backend unit testing

### DIFF
--- a/deploy/template/supervisor_site.conf
+++ b/deploy/template/supervisor_site.conf
@@ -1,5 +1,5 @@
 [program:{{app_name}}]
-command={{srv_dir}}/{{app_name}}/env/bin/python {{srv_dir}}/{{app_name}}/env/bin/gunicorn --reload --workers 4 --bind 127.0.0.1:5000 {{app_run}}:app
+command={{srv_dir}}/{{app_name}}/env/bin/python {{srv_dir}}/{{app_name}}/env/bin/gunicorn --reload --workers 4 --bind 127.0.0.1:5000 {{app_run}}:create_app\(\)
 directory={{srv_dir}}/{{app_name}}/src
 user=root
 stdout_logfile={{srv_dir}}/{{app_name}}/log/app.log

--- a/manage.py
+++ b/manage.py
@@ -3,12 +3,12 @@ import unittest
 
 from flask.ext.script import Manager
 
-from server import app
+from server import create_app
 from server.models import db
 
 from server.models import Lecturer, Course, Lecture, Comment
 
-manager = Manager(app)
+manager = Manager(create_app)
 
 
 @manager.command

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ MarkupSafe==0.23
 SQLAlchemy==1.0.8
 Werkzeug==0.10.4
 itsdangerous==0.24
+Flask-Testing==0.4.2

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,4 +1,4 @@
-from os import path
+import os
 
 from flask import Flask
 
@@ -6,15 +6,22 @@ from .models import db
 from .main.main import main
 from .resources import api
 
-app = Flask(__name__)
 
-app.config.from_object('config')
-if not app.config.from_envvar('IFS_SETTINGS', silent=True):
-    app.config.from_pyfile('/etc/ifs.cfg', silent=True)
-    app.config.from_pyfile(path.expanduser('~/.ifs.cfg'), silent=True)
+def create_app(config=None):
+    app = Flask(__name__)
 
-app.register_blueprint(main)
+    app.config.from_object('config')
 
-db.init_app(app)
+    if not app.config.from_envvar('IFS_SETTINGS', silent=True):
+        app.config.from_pyfile('/etc/ifs.cfg', silent=True)
+        app.config.from_pyfile(os.path.expanduser('~/.ifs.cfg'), silent=True)
 
-api.init_app(app)
+    if config:
+        app.config.update(config)
+
+    app.register_blueprint(main)
+
+    db.init_app(app)
+    api.init_app(app)
+
+    return app

--- a/server/tests/base.py
+++ b/server/tests/base.py
@@ -1,22 +1,16 @@
-import tempfile
-import unittest
-import os
-from server import app
+from server import create_app
 from server.models import db
 
+from flask.ext.testing import TestCase
 
-class BaseTestCase(unittest.TestCase):
+
+class BaseTestCase(TestCase):
+    def create_app(self):
+        return create_app({'SQLALCHEMY_DATABASE_URI': 'sqlite://'})
 
     def setUp(self):
-        self.db_fd, self.test_db_path = tempfile.mkstemp('.db')
-        # test_db_uri = 'sqlite:///{}'.format(self.test_db_path)
-        # app.config['SQLALCHEMY_DATABASE_URI'] = test_db_uri
-        app.config['TESTING'] = True
-        self.app = app.test_client()
-
-        db.drop_all()
         db.create_all()
 
     def tearDown(self):
-        os.close(self.db_fd)
-        os.unlink(self.test_db_path)
+        db.session.remove()
+        db.drop_all()

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -24,22 +24,22 @@ class GetCommentsApiTest(BaseTestCase):
         db.session.commit()
 
     def test_success(self):
-        rv = self.app.get('/api/0/lectures/1/comments')
+        rv = self.client.get('/api/0/lectures/1/comments')
         assert rv.status_code == 200
 
     def test_lecture_not_found(self):
-        rv = self.app.get('/api/0/lectures/2/comments')
+        rv = self.client.get('/api/0/lectures/2/comments')
         assert rv.status_code == 404
 
     def test_list(self):
-        rv = self.app.get('/api/0/lectures/1/comments')
+        rv = self.client.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 
         response = json.loads(rv.data.decode('utf-8'))
         assert len(response['comments']) == 2
 
     def test_content(self):
-        rv = self.app.get('/api/0/lectures/1/comments')
+        rv = self.client.get('/api/0/lectures/1/comments')
         assert rv.headers['Content-Type'] == 'application/json'
 
         response = json.loads(rv.data.decode('utf-8'))
@@ -63,13 +63,13 @@ class PostCommentsApiTest(BaseTestCase):
         db.session.commit()
 
     def test_success(self):
-        rv = self.app.post('/api/0/lectures/1/comments', data=dict(
+        rv = self.client.post('/api/0/lectures/1/comments', data=dict(
             data='hello!'
         ))
         assert rv.status_code == 200
 
     def test_response(self):
-        rv = self.app.post('/api/0/lectures/1/comments', data=dict(
+        rv = self.client.post('/api/0/lectures/1/comments', data=dict(
             data='hello!'
         ))
         assert rv.status_code == 200
@@ -79,11 +79,11 @@ class PostCommentsApiTest(BaseTestCase):
         assert response['id'] >= 0
 
     def test_lecture_not_found(self):
-        rv = self.app.post('/api/0/lectures/2/comments')
+        rv = self.client.post('/api/0/lectures/2/comments')
         assert rv.status_code == 404
 
     def test_no_data(self):
-        rv = self.app.post('/api/0/lectures/1/comments')
+        rv = self.client.post('/api/0/lectures/1/comments')
         assert rv.status_code == 400
 
 
@@ -103,15 +103,15 @@ class GetLectureApiTest(BaseTestCase):
         db.session.commit()
 
     def test_success(self):
-        rv = self.app.get('/api/0/lectures/1')
+        rv = self.client.get('/api/0/lectures/1')
         assert rv.status_code == 200
 
     def test_lecture_not_found(self):
-        rv = self.app.get('/api/0/lectures/2')
+        rv = self.client.get('/api/0/lectures/2')
         assert rv.status_code == 404
 
     def test_content(self):
-        rv = self.app.get('/api/0/lectures/1')
+        rv = self.client.get('/api/0/lectures/1')
         assert rv.headers['Content-Type'] == 'application/json'
 
         response = json.loads(rv.data.decode('utf-8'))


### PR DESCRIPTION
IFS-60. Use Flask-Testing plugin to manage TestCases. The problem was
that application was initialized on module import, using provided
config. When we were changing database on testing one, session remained
untouched.

New approach creates application for each test based on config and
initilize new database connection.
In addition, in-memory sqltile database is now used for tests.