### PR TITLE
IFS-81: Add submissionTime property to comments from 'get-comments' API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -239,6 +239,10 @@ Content:
                     "rating": {
                         "description": "Rating from the current client. See 'Get Comment Rating' API",
                         "type": "integer"
+                    },
+                    "submissionTime": {
+                        "description": "Time point when comment was submitted in ISO format (ISO 8601)"
+                        "type": "string"
                     }
                 }
             }


### PR DESCRIPTION
Please just verify that this is enough to implement the front end for IFS-66.