### PR TITLE
Fix engagement API last parameter not working correctly

### DIFF
--- a/server/resources.py
+++ b/server/resources.py
@@ -92,7 +92,7 @@ class CommentListResource(Resource):
 class EngagementListResource(Resource):
     def get(self, lecture_id):
         parser = reqparse.RequestParser()
-        parser.add_argument('last', location='args', type=bool)
+        parser.add_argument('last', location='args', type=lambda last: last == 'true')
         args = parser.parse_args()
 
         lecture = Lecture.query.filter(Lecture.id == lecture_id).first()

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -482,6 +482,27 @@ class GetEngagementsApiTest(BaseTestCase):
         for engagement in response:
             assert dateutil.parser.parse(engagement['time']) == last_time
 
+    def test_last_false(self):
+        starttime = datetime(2015, 11, 19, 10)
+        for user in range(0, 2):
+            set_client_id_cookie(self.client, str(user))
+            for i in range(0, 10):
+                time = starttime + timedelta(minutes=10*i)
+                interest = 1
+                challenge = 0
+                eng = Engagement(challenge, interest, time, str(user), self.lecture)
+                db.session.add(eng)
+        db.session.commit()
+
+        rv = self.client.get('/api/0/lectures/1/engagements?last=false')
+        assert rv.status_code == 200
+        assert rv.headers['Content-Type'] == 'application/json'
+
+        response = json.loads(rv.data.decode('utf-8'))
+        assert isinstance(response, list)
+
+        assert len(response) == 20
+
 
 class SetCommentRatingApiTest(BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
Anything except than 0 would be True, so lats=false would still be True.