### PR TITLE
IFS-99: APIs for login (lecturer)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,8 @@
     * [Get Comment Rating](#get-rating)
     * [Get Engagements](#get-engagements)
     * [Add Engagement Update](#add-engagement)
+    * [Login](#login)
+    * [Check Login](#check-login)
 * [Format](#format)
 
 ## <a name="intro"></a>Inroduction
@@ -571,6 +573,110 @@ Content:
 
 last are set by `/lectures/:lecture-id/engagements?last=true`
 
+### <a name="login"></a>Login
+
+Login as a lecturer
+
+#### URL
+
+`/login`
+
+#### Method
+
+POST
+
+#### Data Parameters
+
+##### Required
+
+* `email=[string]` Lectures registered email address.
+* `password=[string]` Hashed password using SHA256.
+* `remember=[boolean]` Flag for exstending the expiration time.
+
+#### Success Responses
+
+##### Success
+
+Code: 200
+
+Content:
+```
+{
+    "description": "Flag for success",
+    "type": "boolean"
+}
+```
+
+#### Error Responses
+
+##### Wrong user credentials
+
+Either the email or password or both was wrong.
+See error message for details.
+
+Code: 404
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "message": {
+            "description": "Error message",
+            "type": "string"
+        }
+    }
+}
+```
+
+### <a name="check-login"></a>Check Login
+
+Check if the user is still logged id.
+
+#### URL
+
+`/login`
+
+#### Method
+
+GET
+
+#### Success Responses
+
+##### Valid user token
+
+The user is still logged in.
+
+Code: 200
+
+Content:
+```
+{
+    "description": "Flag for success",
+    "type": "boolean"
+}
+```
+
+#### Error Responses
+
+##### Invalid user token
+
+The user is not logged in.
+
+Code: 404
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "message": {
+            "description": "Error message",
+            "type": "string"
+        }
+    }
+}
+```
 
 ## <a name="format"></a>Format
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -597,7 +597,20 @@ POST
 
 ##### Success
 
-Code: 204
+Code: 200
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "username": {
+            "description": "The username of the lecturer logging in",
+            "type": "string"
+        }
+    }
+}
+```
 
 #### Error Responses
 
@@ -639,7 +652,20 @@ GET
 
 The user is still logged in.
 
-Code: 204
+Code: 200
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "username": {
+            "description": "The username of the lecturer logging in",
+            "type": "string"
+        }
+    }
+}
+```
 
 #### Error Responses
 
@@ -682,25 +708,6 @@ POST
 Logging out user.
 
 Code: 204
-
-#### Error Responses
-
-##### Could not logout user
-
-Code: 403
-
-Content:
-```
-{
-    "type": "object",
-    "properties": {
-        "message": {
-            "description": "Error message",
-            "type": "string"
-        }
-    }
-}
-```
 
 ## <a name="format"></a>Format
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -597,7 +597,7 @@ POST
 
 ##### Success
 
-Code: 200
+Code: 204
 
 #### Error Responses
 
@@ -606,7 +606,7 @@ Code: 200
 Either the email or password or both was wrong.
 See error message for details.
 
-Code: 401
+Code: 403
 
 Content:
 ```
@@ -639,7 +639,7 @@ GET
 
 The user is still logged in.
 
-Code: 200
+Code: 204
 
 #### Error Responses
 
@@ -647,7 +647,7 @@ Code: 200
 
 The user is not logged in.
 
-Code: 401
+Code: 403
 
 Content:
 ```
@@ -681,13 +681,13 @@ POST
 
 Logging out user.
 
-Code: 200
+Code: 204
 
 #### Error Responses
 
 ##### Could not logout user
 
-Code: 401
+Code: 403
 
 Content:
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,6 +15,7 @@
     * [Add Engagement Update](#add-engagement)
     * [Login](#login)
     * [Check Login](#check-login)
+    * [logout] (#logout)
 * [Format](#format)
 
 ## <a name="intro"></a>Inroduction
@@ -579,7 +580,7 @@ Login as a lecturer
 
 #### URL
 
-`/login`
+`/auth/login`
 
 #### Method
 
@@ -591,7 +592,6 @@ POST
 
 * `email=[string]` Lectures registered email address.
 * `password=[string]` Hashed password using SHA256.
-* `remember=[boolean]` Flag for exstending the expiration time.
 
 #### Success Responses
 
@@ -602,8 +602,8 @@ Code: 200
 Content:
 ```
 {
-    "description": "Flag for success",
     "type": "boolean"
+    "description": "Flag for success",
 }
 ```
 
@@ -635,7 +635,7 @@ Check if the user is still logged id.
 
 #### URL
 
-`/login`
+`/auth/login`
 
 #### Method
 
@@ -662,6 +662,54 @@ Content:
 ##### Invalid user token
 
 The user is not logged in.
+
+Code: 404
+
+Content:
+```
+{
+    "type": "object",
+    "properties": {
+        "message": {
+            "description": "Error message",
+            "type": "string"
+        }
+    }
+}
+```
+
+
+### <a name="logout"></a>Logout
+
+Logout user
+
+#### URL
+
+`/auth/logout`
+
+#### Method
+
+GET
+
+#### Success Responses
+
+##### Success
+
+Logging out user.
+
+Code: 200
+
+Content:
+```
+{
+    "description": "Flag for success",
+    "type": "boolean"
+}
+```
+
+#### Error Responses
+
+##### Could not logout user
 
 Code: 404
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@
     * [Add Engagement Update](#add-engagement)
     * [Login](#login)
     * [Check Login](#check-login)
-    * [logout] (#logout)
+    * [Logout] (#logout)
 * [Format](#format)
 
 ## <a name="intro"></a>Inroduction
@@ -599,14 +599,6 @@ POST
 
 Code: 200
 
-Content:
-```
-{
-    "type": "boolean"
-    "description": "Flag for success",
-}
-```
-
 #### Error Responses
 
 ##### Wrong user credentials
@@ -614,7 +606,7 @@ Content:
 Either the email or password or both was wrong.
 See error message for details.
 
-Code: 404
+Code: 401
 
 Content:
 ```
@@ -649,21 +641,13 @@ The user is still logged in.
 
 Code: 200
 
-Content:
-```
-{
-    "description": "Flag for success",
-    "type": "boolean"
-}
-```
-
 #### Error Responses
 
 ##### Invalid user token
 
 The user is not logged in.
 
-Code: 404
+Code: 401
 
 Content:
 ```
@@ -689,7 +673,7 @@ Logout user
 
 #### Method
 
-GET
+POST
 
 #### Success Responses
 
@@ -699,19 +683,11 @@ Logging out user.
 
 Code: 200
 
-Content:
-```
-{
-    "description": "Flag for success",
-    "type": "boolean"
-}
-```
-
 #### Error Responses
 
 ##### Could not logout user
 
-Code: 404
+Code: 401
 
 Content:
 ```


### PR DESCRIPTION
I am not entirely sure about the `remember` flag. Maybe changing the `/login` success code to 204 No Content as there is no content?

When I am thinking about it, I guess it was wrong doing a `POST` for signing in as we don really post anything? and thus should change it to `GET`.  The reason I did it like this was that we can check if the user still has an valid token by `GET /login` making the API a tiny bit simpler. But again, if POST is wrong, we can do `GET /login/check`.